### PR TITLE
Update for modern servant and add Build module

### DIFF
--- a/circlehs.cabal
+++ b/circlehs.cabal
@@ -41,6 +41,7 @@ library
                         , Network.CircleCI.CheckoutKey
                         , Network.CircleCI.Environment
                         , Network.CircleCI.Cache
+                        , Network.CircleCI.Build
                         -- Commonly used stuff.
                         , Network.CircleCI.Common.Types
                         , Network.CircleCI.Common.Run

--- a/circlehs.cabal
+++ b/circlehs.cabal
@@ -54,8 +54,8 @@ library
                         , text                  >= 1.2.2.1  && < 2
                         , aeson                 >= 0.9.0.1  && < 1.5
                         , unordered-containers  >= 0.2.5.1  && < 0.3
-                        , servant               >= 0.7      && < 0.14
-                        , servant-client        >= 0.10     && < 0.15
+                        , servant               >= 0.7      && < 0.16
+                        , servant-client        >= 0.10     && < 0.16
                         , time                  >= 1.4.1.1  && < 1.9
                         , mtl                   >= 2.2.1    && < 2.3
                         , transformers          >= 0.4.2.0  && < 0.6

--- a/circlehs.cabal
+++ b/circlehs.cabal
@@ -50,15 +50,15 @@ library
 
   build-depends:          base                  >= 4.7      && < 5
                         , text                  >= 1.2.2.1  && < 2
-                        , aeson                 >= 0.9.0.1  && < 0.12
+                        , aeson                 >= 0.9.0.1  && < 1.5
                         , unordered-containers  >= 0.2.5.1  && < 0.3
-                        , servant               >= 0.7      && < 0.9
-                        , servant-client        >= 0.7      && < 0.9
-                        , time                  >= 1.4.1.1  && < 1.7
+                        , servant               >= 0.7      && < 0.15
+                        , servant-client        >= 0.7      && < 0.15
+                        , time                  >= 1.4.1.1  && < 1.9
                         , mtl                   >= 2.2.1    && < 2.3
                         , transformers          >= 0.4.2.0  && < 0.6
-                        , http-client           >= 0.4.24   && < 0.5
-                        , http-client-tls       >= 0.2.2    && < 0.5
+                        , http-client           >= 0.4.24   && < 0.6
+                        , http-client-tls       >= 0.2.2    && < 0.4
 
   default-language:     Haskell2010
   ghc-options:          -Wall -fno-warn-unused-binds

--- a/circlehs.cabal
+++ b/circlehs.cabal
@@ -47,13 +47,14 @@ library
 
   other-modules:          Network.CircleCI.Common.HTTPS
                         , Network.CircleCI.Common.URL
+                        , Network.CircleCI.Common.Lift
 
   build-depends:          base                  >= 4.7      && < 5
                         , text                  >= 1.2.2.1  && < 2
                         , aeson                 >= 0.9.0.1  && < 1.5
                         , unordered-containers  >= 0.2.5.1  && < 0.3
-                        , servant               >= 0.7      && < 0.15
-                        , servant-client        >= 0.7      && < 0.15
+                        , servant               >= 0.7      && < 0.14
+                        , servant-client        >= 0.10     && < 0.15
                         , time                  >= 1.4.1.1  && < 1.9
                         , mtl                   >= 2.2.1    && < 2.3
                         , transformers          >= 0.4.2.0  && < 0.6

--- a/circlehs.cabal
+++ b/circlehs.cabal
@@ -54,9 +54,9 @@ library
                         , text                  >= 1.2.2.1  && < 2
                         , aeson                 >= 0.9.0.1  && < 1.5
                         , unordered-containers  >= 0.2.5.1  && < 0.3
-                        , servant               >= 0.7      && < 0.14
+                        , servant               >= 0.7      && < 0.15
                         , servant-client        >= 0.10     && < 0.15
-                        , time                  >= 1.4.1.1  && < 1.9
+                        , time                  >= 1.4.1.1  && < 1.10
                         , mtl                   >= 2.2.1    && < 2.3
                         , transformers          >= 0.4.2.0  && < 0.6
                         , http-client           >= 0.4.24   && < 0.6

--- a/src/Network/CircleCI/Build.hs
+++ b/src/Network/CircleCI/Build.hs
@@ -1,0 +1,217 @@
+{-|
+Module      : Network.CircleCI.Build
+Copyright   : (c) Ben Gamari, 2018
+License     : MIT
+Maintainer  : ben@well-typed.com
+Stability   : alpha
+API calls for triggering and querying builds.
+-}
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE MultiWayIf #-}
+
+module Network.CircleCI.Build (
+    -- * API calls
+      triggerBuild
+    , getBuild
+    -- * Types for calls and response
+    -- ** Querying
+    , BuildInfo(..)
+    , BuildOutcome(..)
+    , BuildLifecycle(..)
+    -- ** Triggering
+    , TagName
+    , Revision
+    , TriggerBuildOptions(..)
+    , BuildTarget(..)
+    -- ** General
+    , module Network.CircleCI.Common.Types
+    , module Network.CircleCI.Common.Run
+) where
+
+import           Network.CircleCI.Common.Lift
+import           Network.CircleCI.Common.Types
+import           Network.CircleCI.Common.Run
+
+import           Control.Monad                  ( mzero )
+import           Control.Monad.Reader           ( ask )
+import           Data.Aeson
+import           Data.Aeson.Types
+import qualified Data.Proxy                     as P
+import           Data.Text                      ( Text )
+import           Data.HashMap.Strict            ( HashMap )
+
+import           Servant.API
+import           Servant.Client
+
+-- | The name of a git tag.
+type TagName = Text
+
+-- | A git commit SHA.
+type Revision = Text
+
+-- | Trigger a build of a tag. Based on https://circleci.com/docs/api/v1-reference/#new-build.
+--
+-- Usage example:
+--
+-- @
+-- {-\# LANGUAGE OverloadedStrings \#-}
+-- {-\# LANGUAGE LambdaCase \#-}
+--
+-- import Network.CircleCI
+--
+-- main :: IO ()
+-- main = runCircleCI (triggerBuildTag (ProjectPoint "denisshevchenko" "circlehs") "a-tag")
+--                    (AccountAPIToken "e64c674195bbc0d0be3efa2whatever")
+--     >>= \\case
+--         Left problem  -> print problem
+--         Right buildNo -> print buildNo
+-- @
+triggerBuild :: ProjectPoint -> TriggerBuildOptions -> CircleCIResponse BuildInfo
+triggerBuild project opts = do
+    AccountAPIToken token <- ask
+    liftClientM $ servantTriggerBuild
+        (userName project)
+        (projectName project)
+        (Just token)
+        opts
+
+-- | Get information about a build.
+getBuild :: ProjectPoint -> BuildNumber -> CircleCIResponse BuildInfo
+getBuild project build = do
+    AccountAPIToken token <- ask
+    liftClientM $ servantGetBuild
+        (userName project)
+        (projectName project)
+        build
+        (Just token)
+
+-------------------------------------------------------------------------------
+-- API types for Servant ------------------------------------------------------
+-------------------------------------------------------------------------------
+
+-- Complete API to trigger builds
+type BuildAPI =
+         TriggerBuild
+    :<|> GetBuild
+
+-- Trigger a build.
+type TriggerBuild =
+       "project"
+    :> Capture "username" UserName
+    :> Capture "project" ProjectName
+    :> QueryParam "circle-token" Token
+    :> ReqBody '[JSON] TriggerBuildOptions
+    :> Post '[JSON] BuildInfo
+    -- POST: /project/:username/:project?circle-token=:token
+
+data TriggerBuildOptions = TriggerBuildOptions {
+      triggerBuildTarget :: BuildTarget
+    , triggerBuildParams :: HashMap Text Text
+    }
+
+instance ToJSON TriggerBuildOptions where
+    toJSON opts =
+        object $ [ "build_parameters" .= triggerBuildParams opts ]
+              ++ target
+      where
+        target =
+            case triggerBuildTarget opts of
+              BuildRevision rev -> [ "revision" .= rev ]
+              BuildTag tag      -> [ "tag" .= tag ]
+              BuildHead         -> []
+
+-- | What should be built?
+data BuildTarget = BuildRevision Revision
+                   -- ^ build a particular git revision
+                 | BuildTag TagName
+                   -- ^ build a particular git tag
+                 | BuildHead
+                   -- ^ build the head of the default branch
+
+-- Get information about a build
+type GetBuild =
+       "project"
+    :> Capture "username" UserName
+    :> Capture "project" ProjectName
+    :> Capture "build number" BuildNumber
+    :> QueryParam "circle-token" Token
+    :> Get '[JSON] BuildInfo
+    -- GET: /project/:username/:project/:build_num?circle-token=:tokenh
+
+-- | Info about single build.
+data BuildInfo = BuildInfo {
+      outcome     :: Maybe BuildOutcome
+    , lifecycle   :: BuildLifecycle
+    , number      :: BuildNumber
+    , commit      :: Text
+    } deriving (Eq, Show)
+
+-- How we create BuildInfo from JSON.
+instance FromJSON BuildInfo where
+    parseJSON (Object o) = BuildInfo
+        <$> (o .:? "outcome" >>= traverse toBuildOutcome)
+        <*> (o .: "lifecycle" >>= toBuildLifecycle)
+        <*>  o .: "build_num"
+        <*>  o .: "vcs_revision"
+    parseJSON _ = mzero
+
+toBuildOutcome :: Text -> Parser BuildOutcome
+toBuildOutcome "success"             = return BuildSuccess
+toBuildOutcome "failed"              = return BuildFailed
+toBuildOutcome "canceled"            = return BuildCanceled
+toBuildOutcome "no_tests"            = return BuildNoTests
+toBuildOutcome "infrastructure_fail" = return BuildInfrastructureFail
+toBuildOutcome "timedout"            = return BuildTimedOut
+toBuildOutcome _                     = fail "unknown build outcome"
+
+-- | Build outcome.
+data BuildOutcome = BuildSuccess
+                  | BuildFailed
+                  | BuildCanceled
+                  | BuildNoTests
+                  | BuildInfrastructureFail
+                  | BuildTimedOut
+                  deriving (Eq, Show)
+
+toBuildLifecycle :: Text -> Parser BuildLifecycle
+toBuildLifecycle "queued"      = return BuildQueued
+toBuildLifecycle "scheduled"   = return BuildScheduled
+toBuildLifecycle "not_run"     = return BuildNotRun
+toBuildLifecycle "not_running" = return BuildNotRunning
+toBuildLifecycle "running"     = return BuildRunning
+toBuildLifecycle "finished"    = return BuildFinished
+toBuildLifecycle _             = fail "unknown build lifecycle"
+
+-- | Build lifecycle.
+data BuildLifecycle = BuildQueued
+                    | BuildScheduled
+                    | BuildNotRun
+                    | BuildNotRunning
+                    | BuildRunning
+                    | BuildFinished
+                    deriving (Eq, Show)
+
+-------------------------------------------------------------------------------
+-- API client calls for Servant -----------------------------------------------
+-------------------------------------------------------------------------------
+
+servantTriggerBuild :: UserName
+                    -> ProjectName
+                    -> Maybe Token
+                    -> TriggerBuildOptions
+                    -> ClientM BuildInfo
+
+servantGetBuild :: UserName
+                -> ProjectName
+                -> BuildNumber
+                -> Maybe Token
+                -> ClientM BuildInfo
+
+servantTriggerBuild
+    :<|> servantGetBuild = client buildAPI
+
+buildAPI :: P.Proxy BuildAPI
+buildAPI = P.Proxy

--- a/src/Network/CircleCI/Common/Lift.hs
+++ b/src/Network/CircleCI/Common/Lift.hs
@@ -1,0 +1,26 @@
+{-|
+Module      : Network.CircleCI.Common.Lift
+Copyright   : (c) Ben Gamari, 2018
+License     : MIT
+Maintainer  : ben@well-typed.com
+Stability   : alpha
+
+Lift @servant-client@ computations into the 'CircleCIResponse' monad.
+-}
+
+module Network.CircleCI.Common.Lift (
+    liftClientM
+) where
+
+import           Servant.Client hiding (manager)
+import           Control.Monad.Reader
+import           Network.CircleCI.Common.HTTPS
+import           Network.CircleCI.Common.Types
+import           Network.CircleCI.Common.URL
+
+-- | Lift a 'ClientM' computation into the 'CircleCIResponse' monad.
+liftClientM :: ClientM a -> CircleCIResponse a
+liftClientM action = do
+    manager <- httpsManager
+    let env = mkClientEnv manager apiBaseUrl
+    liftIO $ runClientM action env

--- a/src/Network/CircleCI/Common/Run.hs
+++ b/src/Network/CircleCI/Common/Run.hs
@@ -18,4 +18,3 @@ import           Control.Monad.Reader
 -- instead of passing it as an explicit argument.
 runCircleCI :: ReaderT t IO a -> t -> IO a
 runCircleCI = runReaderT
-

--- a/src/Network/CircleCI/Common/Types.hs
+++ b/src/Network/CircleCI/Common/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 {-|
 Module      : Network.CircleCI.Common.Types
 Copyright   : (c) Denis Shevchenko, 2016
@@ -22,6 +24,8 @@ module Network.CircleCI.Common.Types (
 ) where
 
 import           Servant.Client
+import           Servant.API
+import           Data.Aeson
 import           Data.Text                ( Text )
 import           Control.Monad.Reader
 
@@ -44,7 +48,7 @@ type BranchName = Text
 
 -- | Number of project's build on CircleCI.
 newtype BuildNumber = BuildNumber Int
-                    deriving (Eq, Show)
+                    deriving (Eq, Show, ToHttpApiData, FromJSON, ToJSON)
 
 -- | User email address.
 type Email = Text

--- a/src/Network/CircleCI/Common/URL.hs
+++ b/src/Network/CircleCI/Common/URL.hs
@@ -12,7 +12,7 @@ module Network.CircleCI.Common.URL (
     apiBaseUrl
 ) where
 
-import           Servant.Common.BaseUrl
+import           Servant.Client
 
 -- | Base URL for all API calls. For API v1 it's @https://circleci.com/api/v1/@.
 apiBaseUrl :: BaseUrl

--- a/src/Network/CircleCI/Project.hs
+++ b/src/Network/CircleCI/Project.hs
@@ -25,22 +25,18 @@ module Network.CircleCI.Project (
     , module Network.CircleCI.Common.Run
 ) where
 
-import           Network.CircleCI.Common.URL
+import           Network.CircleCI.Common.Lift
 import           Network.CircleCI.Common.Types
-import           Network.CircleCI.Common.HTTPS
 import           Network.CircleCI.Common.Run
 
 import           Control.Monad                  ( mzero )
-import           Control.Monad.Except           ( runExceptT )
 import           Control.Monad.Reader           ( ask )
-import           Control.Monad.IO.Class         ( liftIO )
 import           Data.Aeson
 import           Data.Aeson.Types
 import           Data.HashMap.Strict
 import qualified Data.Proxy                     as P
 import           Data.Text                      ( Text )
 import           Data.Time.Clock                ( UTCTime )
-import           Network.HTTP.Client            ( Manager )
 
 import           Servant.API
 import           Servant.Client
@@ -65,11 +61,7 @@ import           Servant.Client
 getProjectsInfo :: CircleCIResponse [ProjectInfo] -- ^ Info about projects.
 getProjectsInfo = do
     AccountAPIToken token <- ask
-    liftIO . runExceptT $ do
-        manager <- httpsManager
-        servantGetProjectsInfo (Just token)
-                               manager
-                               apiBaseUrl
+    liftClientM $ servantGetProjectsInfo (Just token)
 
 -- | Info about single project.
 data ProjectInfo = ProjectInfo {
@@ -223,8 +215,6 @@ type GetProjectsInfoCall =
 -------------------------------------------------------------------------------
 
 servantGetProjectsInfo :: Maybe Token
-                       -> Manager
-                       -> BaseUrl
                        -> ClientM [ProjectInfo]
 servantGetProjectsInfo = client projectsInfoAPI
 

--- a/src/Network/CircleCI/User.hs
+++ b/src/Network/CircleCI/User.hs
@@ -27,22 +27,18 @@ module Network.CircleCI.User (
     , module Network.CircleCI.Common.Run
 ) where
 
-import           Network.CircleCI.Common.URL
+import           Network.CircleCI.Common.Lift
 import           Network.CircleCI.Common.Types
-import           Network.CircleCI.Common.HTTPS
 import           Network.CircleCI.Common.Run
 
 import           Control.Monad                  ( mzero )
-import           Control.Monad.Except           ( runExceptT )
 import           Control.Monad.Reader           ( ask )
-import           Control.Monad.IO.Class         ( liftIO )
 import           Data.Aeson
 import           Data.Aeson.Types
 import           Data.HashMap.Strict
 import qualified Data.Proxy                     as P
 import           Data.Text                      ( Text )
 import           Data.Time.Clock                ( UTCTime )
-import           Network.HTTP.Client            ( Manager )
 
 import           Servant.API
 import           Servant.Client
@@ -67,11 +63,7 @@ import           Servant.Client
 getUserInfo :: CircleCIResponse UserInfo -- ^ Info about the signed in user.
 getUserInfo = do
     AccountAPIToken token <- ask
-    liftIO . runExceptT $ do
-        manager <- httpsManager
-        servantGetUserInfo (Just token)
-                           manager
-                           apiBaseUrl
+    liftClientM $ servantGetUserInfo (Just token)
 
 -- | User's analytics id. For example, @"6fc20e13-008e-4dc9-b158-ababd33a099d"@.
 type AnalyticsId = Text
@@ -202,8 +194,6 @@ type GetUserInfoCall =
 -------------------------------------------------------------------------------
 
 servantGetUserInfo :: Maybe Token
-                   -> Manager
-                   -> BaseUrl
                    -> ClientM UserInfo
 servantGetUserInfo = client userAPI
 


### PR DESCRIPTION
Here we update version bounds, port to the codebase to `servant-client`'s new `ClientM` monad, and add support for triggering builds.